### PR TITLE
Removed broken economics link

### DIFF
--- a/posts/words-words-words.html
+++ b/posts/words-words-words.html
@@ -195,7 +195,6 @@
 					<li><a href="http://www.econlinks.com/glossary/" target="_blank">Glossary</a> @ Dr. T's EconLinks</li>
 					<li><a href="http://www.econlib.org/library/CEETitles.html" target="_blank">Concise Encyclopedia of Economic Terms</a></li>
 					<li><a href="http://college.cengage.com/economics/taylor/macro/student/glossary/glossary.html" target="_blank">Principles of Macroeconomics Glossary</a></li>
-					<li><a href="http://www.economicswisconsin.org/guide/glossary.htm" target="_blank">Glossary of Economic Terms and Definitions</a></li>
 				</ul>
 				<p><b>More online glossary lists:</b></p>
 				<ul>


### PR DESCRIPTION
The domain for http://www.economicswisconsin.org/guide/glossary.htm disappeared